### PR TITLE
feat: add wearable-preview at the left of the list by clicking the entity id

### DIFF
--- a/app/compare.tsx
+++ b/app/compare.tsx
@@ -1,8 +1,10 @@
 'use client'
 
-import { Fragment, useEffect, useState } from 'react'
 import { Dialog, Transition } from '@headlessui/react'
 import { XMarkIcon } from '@heroicons/react/24/outline'
+import { Fragment, useEffect, useRef, useState } from 'react'
+
+import { PreviewMessageType, sendMessage } from '@dcl/schemas/dist/dapps/preview'
 
 const catalystBaseUrl = 'https://peer.decentraland.org'
 const cdnBaseUrl = 'https://profile-images-bucket-43d0c58.decentraland.org/v1/entities'
@@ -28,6 +30,7 @@ export default function Compare() {
   const [entities, setEntities] = useState<EntityData[]>([])
   const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false)
   const [slideOverOpen, setSlideOver] = useState<EntityData | null>(null)
+  const avatarPreviewRef = useRef(null)
 
   function loadProfiles(entityIds: string[] = []) {
     fetch(
@@ -56,8 +59,22 @@ export default function Compare() {
   }
 
   useEffect(() => {
+    console.log('wmeifwemofmwieofmwioep fiweo')
     loadProfiles()
   }, [])
+
+  useEffect(() => {
+    if (slideOverOpen?.address) {
+      const refWindow = (avatarPreviewRef.current as any)?.contentWindow
+      if (refWindow) {
+        sendMessage(refWindow, PreviewMessageType.UPDATE, {
+          options: {
+            profile: slideOverOpen.id
+          }
+        })
+      }
+    }
+  }, [slideOverOpen])
 
   return (
     <div className="bg-white">
@@ -228,62 +245,74 @@ export default function Compare() {
         </Dialog>
       </Transition.Root>
 
-      <div className="text-sm m-4">
-        {entities.map((entityData) => (
-          <div key={entityData.id} className="mt-6 grid gap-x-2 grid-cols-4 text-gray-500 border-2 p-2">
-            <div className="col-span-4 text-xs text-center">
-              <span
-                className="text-indigo-600 hover:text-indigo-800 hover:cursor-pointer"
-                onClick={() => setSlideOver(entityData)}
-              >
-                {' '}
-                {entityData.id}
-              </span>{' '}
-              -{' '}
-              <a
-                href={`https://decentraland.org/profile/accounts/${entityData.address}`}
-                target="_blank"
-                className="text-indigo-600"
-              >
-                {entityData.address}
-              </a>
-            </div>
-
-            <div className="col-span-1 text-xs text-center">Body (Catalyst)</div>
-            <div className="col-span-1 text-xs text-center">Body (CDN)</div>
-            <div className="col-span-1 text-xs text-center">Face (Catalyst)</div>
-            <div className="col-span-1 text-xs text-center">Face (CDN)</div>
-
-            <div className="col-span-1 text-center">
-              <div className="overflow-hidden h-full w-full">
-                <img
-                  className="object-cover border"
-                  src={`${catalystBaseUrl}/content/contents/${entityData.body}`}
-                  alt=""
-                />
-              </div>
-            </div>
-            <div className="col-span-1 text-center">
-              <div className="overflow-hidden h-full w-full">
-                <img className="object-cover border" src={`${cdnBaseUrl}/${entityData.id}/body.png`} alt="" />
-              </div>
-            </div>
-            <div className="col-span-1 text-center">
-              <div className="overflow-hidden h-full w-full">
-                <img
-                  className="object-cover border"
-                  src={`${catalystBaseUrl}/content/contents/${entityData.face}`}
-                  alt=""
-                />
-              </div>
-            </div>
-            <div className="col-span-1 text-center">
-              <div className="overflow-hidden h-full w-full">
-                <img className="object-cover border" src={`${cdnBaseUrl}/${entityData.id}/face.png`} alt="" />
-              </div>
-            </div>
+      <div className="flex">
+        {entities.length > 0 && (
+          <div className="shrink-0" style={{ height: '600px', width: '300px' }}>
+            <iframe
+              width={'100%'}
+              ref={avatarPreviewRef}
+              height={600}
+              src="https://wearable-preview.decentraland.org"
+            />
           </div>
-        ))}
+        )}
+        <div className="text-sm grow" style={{ maxHeight: '70vh', overflowY: 'auto' }}>
+          {entities.map((entityData) => (
+            <div key={entityData.id} className="mt-6 grid gap-x-2 grid-cols-4 text-gray-500 border-2 p-2">
+              <div className="col-span-4 text-xs text-center">
+                <span
+                  className="text-indigo-600 hover:text-indigo-800 hover:cursor-pointer"
+                  onClick={() => setSlideOver(entityData)}
+                >
+                  {' '}
+                  {entityData.id}
+                </span>{' '}
+                -{' '}
+                <a
+                  href={`https://decentraland.org/profile/accounts/${entityData.address}`}
+                  target="_blank"
+                  className="text-indigo-600"
+                >
+                  {entityData.address}
+                </a>
+              </div>
+
+              <div className="col-span-1 text-xs text-center">Body (Catalyst)</div>
+              <div className="col-span-1 text-xs text-center">Body (CDN)</div>
+              <div className="col-span-1 text-xs text-center">Face (Catalyst)</div>
+              <div className="col-span-1 text-xs text-center">Face (CDN)</div>
+
+              <div className="col-span-1 text-center">
+                <div className="overflow-hidden h-full w-full">
+                  <img
+                    className="object-cover border"
+                    src={`${catalystBaseUrl}/content/contents/${entityData.body}`}
+                    alt=""
+                  />
+                </div>
+              </div>
+              <div className="col-span-1 text-center">
+                <div className="overflow-hidden h-full w-full">
+                  <img className="object-cover border" src={`${cdnBaseUrl}/${entityData.id}/body.png`} alt="" />
+                </div>
+              </div>
+              <div className="col-span-1 text-center">
+                <div className="overflow-hidden h-full w-full">
+                  <img
+                    className="object-cover border"
+                    src={`${catalystBaseUrl}/content/contents/${entityData.face}`}
+                    alt=""
+                  />
+                </div>
+              </div>
+              <div className="col-span-1 text-center">
+                <div className="overflow-hidden h-full w-full">
+                  <img className="object-cover border" src={`${cdnBaseUrl}/${entityData.id}/face.png`} alt="" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   )

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@dcl/schemas": "^14.0.0",
     "@headlessui/react": "^1.7.19",
     "@heroicons/react": "^2.1.5",
     "next": "14.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,6 +36,16 @@
     eslint-plugin-prettier "^5.1.3"
     prettier "^3.3.2"
 
+"@dcl/schemas@^14.0.0":
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-14.0.0.tgz#d967a41046186090f9e3db0a725cff38cd5bdaf3"
+  integrity sha512-w3P/5g/gkYcBUB6+eN1PYdQBaiS8nLh7ldGfUI6GuiHQKvPIC3wS26Dx5i2ukwHrds2koOaqhFdLzHLVDDitQg==
+  dependencies:
+    ajv "^8.11.0"
+    ajv-errors "^3.0.0"
+    ajv-keywords "^5.1.0"
+    mitt "^3.0.1"
+
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
@@ -452,6 +462,18 @@ acorn@^8.9.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.2.tgz#ca0d78b51895be5390a5903c5b3bdcdaf78ae40b"
   integrity sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==
 
+ajv-errors@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-3.0.0.tgz#e54f299f3a3d30fe144161e5f0d8d51196c527bc"
+  integrity sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==
+
+ajv-keywords@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-5.1.0.tgz#69d4d385a4733cdbeab44964a1170a88f87f0e16"
+  integrity sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+
 ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -461,6 +483,16 @@ ajv@^6.12.4:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+ajv@^8.11.0:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
+  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
 
 ansi-regex@^5.0.1:
   version "5.0.1"
@@ -1268,6 +1300,11 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
+fast-uri@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.0.2.tgz#d78b298cf70fd3b752fd951175a3da6a7b48f024"
+  integrity sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row==
+
 fastq@^1.6.0:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.15.0.tgz#d04d07c6a2a68fe4599fea8d2e103a937fae6b3a"
@@ -1799,6 +1836,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
@@ -1931,6 +1973,11 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.0.4.tgz#dbce03740f50a4786ba994c1fb908844d27b038c"
   integrity sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==
+
+mitt@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.1.tgz#ea36cf0cc30403601ae074c8f77b7092cdab36d1"
+  integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
 
 ms@2.1.2:
   version "2.1.2"
@@ -2350,6 +2397,11 @@ regexp.prototype.flags@^1.5.0, regexp.prototype.flags@^1.5.1:
     call-bind "^1.0.2"
     define-properties "^1.2.0"
     set-function-name "^2.0.0"
+
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 resolve-from@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
After enabling the rendering of entities in https://github.com/decentraland/wearable-preview/pull/117, this uses it for rendering the actual entity listed. The issue was when you compare it with the wrong avatar (by opening the profile) because there are newer deployments.

![image](https://github.com/user-attachments/assets/5076f743-996f-4a2e-a4f7-441a6c146a4b)


